### PR TITLE
Espressif32 framework version specification

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,10 +19,8 @@ src_dir = src
 [libraries]
 
 [com]
-platform = espressif32
+platform = espressif32@6.6.0
 board = esp32s3dev
-platform_packages = 
-  framework-espidf@ 3.50105.0
 monitor_filters = esp32_exception_decoder
 framework = espidf
 build_type = debug

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,6 @@ lib_deps =
 
 [env:LVGL-320-480]
 platform = ${com.platform}
-platform_packages = ${com.platform_packages}	
 board = 320x480
 monitor_filters = ${com.monitor_filters}
 framework = ${com.framework}


### PR DESCRIPTION
## :recycle: Current situation

The project does not compile successfully with the current platformio.ini configuration and the espidf framework configuration. 

## :bulb: Proposed solution

Add the compatible version to the platform definition in platformio.ini and remove the specification of the espidf framework.

### Testing

While the project compiles successfully in VScode on Ubuntu Linux, the resulting binary is not tested on the actual device.

### Reviewer Nudging

Checkout the changes in platformio.ini